### PR TITLE
Fixes Fatal Errors When Exporting Stats

### DIFF
--- a/tcpdf/include/tcpdf_fonts.php
+++ b/tcpdf/include/tcpdf_fonts.php
@@ -1664,6 +1664,7 @@ class TCPDF_FONTS {
 	 * @public static
 	 */
 	public static function unichr($c, $unicode=true) {
+		$c = intval( $c );
 		if (!$unicode) {
 			return chr($c);
 		} elseif ($c <= 0x7F) {

--- a/tcpdf/include/tcpdf_images.php
+++ b/tcpdf/include/tcpdf_images.php
@@ -315,7 +315,7 @@ class TCPDF_IMAGES {
 					if ($n > 0) {
 						$trns = array();
 						for ($i = 0; $i < $n; ++ $i) {
-							$trns[] = ord($t{$i});
+							$trns[] = ord($t[$i]);
 						}
 					}
 				}

--- a/tcpdf/tcpdf.php
+++ b/tcpdf/tcpdf.php
@@ -16539,7 +16539,9 @@ class TCPDF {
 					// get attributes
 					preg_match_all('/([^=\s]*)[\s]*=[\s]*"([^"]*)"/', $element, $attr_array, PREG_PATTERN_ORDER);
 					$dom[$key]['attribute'] = array(); // reset attribute array
-					while (list($id, $name) = each($attr_array[1])) {
+					// while (list($id, $name) = each($attr_array[1])) {
+						foreach ($$attr_array[1] as $id => $name) {
+
 						$dom[$key]['attribute'][strtolower($name)] = $attr_array[2][$id];
 					}
 					if (!empty($css)) {
@@ -16890,10 +16892,10 @@ class TCPDF {
 					if (($dom[$key]['value'] == 'pre') OR ($dom[$key]['value'] == 'tt')) {
 						$dom[$key]['fontname'] = $this->default_monospaced_font;
 					}
-					if (!empty($dom[$key]['value']) AND ($dom[$key]['value'][0] == 'h') AND (intval($dom[$key]['value']{1}) > 0) AND (intval($dom[$key]['value']{1}) < 7)) {
+					if (!empty($dom[$key]['value']) AND ($dom[$key]['value'][0] == 'h') AND (intval($dom[$key]['value'][1]) > 0) AND (intval($dom[$key]['value'][1]) < 7)) {
 						// headings h1, h2, h3, h4, h5, h6
 						if (!isset($dom[$key]['attribute']['size']) AND !isset($dom[$key]['style']['font-size'])) {
-							$headsize = (4 - intval($dom[$key]['value']{1})) * 2;
+							$headsize = (4 - intval($dom[$key]['value'][1])) * 2;
 							$dom[$key]['fontsize'] = $dom[0]['fontsize'] + $headsize;
 						}
 						if (!isset($dom[$key]['style']['font-weight'])) {


### PR DESCRIPTION
Steps to recreate
1. Navigate to /wp-admin/admin.php?page=when-last-login-stats
2. Download PDF Report
3. No fatal error should occur
